### PR TITLE
Fix editing number fields

### DIFF
--- a/cheat-engine/www/cheat/panels/GeneralPanel.js
+++ b/cheat-engine/www/cheat/panels/GeneralPanel.js
@@ -20,7 +20,7 @@ export default {
     
     <v-card-text class="py-0">
         <v-text-field
-            v-model="gold"
+            v-model.number="gold"
             label="Gold"
             outlined
             dense

--- a/cheat-engine/www/cheat/panels/HealthSettingTab.js
+++ b/cheat-engine/www/cheat/panels/HealthSettingTab.js
@@ -21,7 +21,7 @@ export default {
                 style="width: 50px;"
                 hide-details
                 solo
-                v-model="item.hp.hp"
+                v-model.number="item.hp.hp"
                 label="Curr Hp"
                 dense
                 @keydown.self.stop
@@ -38,7 +38,7 @@ export default {
                 style="width: 50px;"
                 hide-details
                 solo
-                v-model="item.mp.mp"
+                v-model.number="item.mp.mp"
                 label="Curr Mp"
                 dense
                 @keydown.self.stop

--- a/cheat-engine/www/cheat/panels/ItemTableTab.js
+++ b/cheat-engine/www/cheat/panels/ItemTableTab.js
@@ -59,7 +59,7 @@ export default {
                 style="width: 60px;"
                 hide-details
                 solo
-                v-model="item.amount"
+                v-model.number="item.amount"
                 label="Amount"
                 dense
                 @keydown.self.stop

--- a/cheat-engine/www/cheat/panels/StatsSettingPanel.js
+++ b/cheat-engine/www/cheat/panels/StatsSettingPanel.js
@@ -55,7 +55,7 @@ export default {
                     <v-col>
                         <v-text-field
                             label="Lv"
-                            v-model="actor.level"
+                            v-model.number="actor.level"
                             outlined
                             dense
                             hide-details
@@ -66,7 +66,7 @@ export default {
                     <v-col>
                         <v-text-field
                             label="EXP"
-                            v-model="actor.exp"
+                            v-model.number="actor.exp"
                             outlined
                             dense
                             hide-details
@@ -85,7 +85,7 @@ export default {
                         md="6">
                         <v-text-field
                             :label="paramNames[paramIdx]"
-                            v-model="actor.param[paramIdx]"
+                            v-model.number="actor.param[paramIdx]"
                             outlined
                             dense
                             hide-details

--- a/cheat-engine/www/cheat/panels/VariableSettingPanel.js
+++ b/cheat-engine/www/cheat/panels/VariableSettingPanel.js
@@ -143,7 +143,10 @@ export default {
 
         onItemChange (item) {
             // modify value
-            $gameVariables.setValue(item.id, item.value)
+            // if the field was a number, make sure we're able to change it to a number
+            // if we don't do this we will set number vars to strings, causing addition to be interpreted as string concatenation
+            // we can't just change the template's model to number because some variables really are strings
+            $gameVariables.setValue(item.id, Number.isNaN(item.value) ? item.value : Number.parseFloat(item.value))
 
             // refresh
             item.value = $gameVariables.value(item.id)


### PR DESCRIPTION
Fixes #11 

Variables like gold, hp, mp, etc. were being set to strings because the textfields' models were not correctly set. This caused issues when games expected to be able to call number prototype methods or when doing addition which could be interpreted as string concatenetation.

Variables in the VariableSettingPanel are only sometimes numbers, so the model can't be directly set to number. Instead, we cast the user's input to a number if the original field value was a number.