### PR TITLE
Set correct type for number variables

### DIFF
--- a/cheat-engine/www/cheat/panels/VariableSettingPanel.js
+++ b/cheat-engine/www/cheat/panels/VariableSettingPanel.js
@@ -142,8 +142,14 @@ export default {
         },
 
         onItemChange (item) {
+            // verify if its number 
+            const number = Number(item.value)
+
+            // set the value with correct type
+			const value = isNaN(number) ? item.value : number; 
+
             // modify value
-            $gameVariables.setValue(item.id, item.value)
+            $gameVariables.setValue(item.id, value)
 
             // refresh
             item.value = $gameVariables.value(item.id)


### PR DESCRIPTION
in VariableSettingPanel.js verify if a variable is a number to set the correct type
fixes issue Fixes paramonos/RPG-Maker-MV-MZ-Cheat-UI-Plugin#17